### PR TITLE
Link to Slack signup

### DIFF
--- a/app/views/homes/_about_us.html.erb
+++ b/app/views/homes/_about_us.html.erb
@@ -10,7 +10,7 @@
           the month.
         </p>
         <div class="about-us__cta">
-          <%= link_to("Join us on Slack!", "#") %>
+          <%= link_to("Join the Community", "https://www.meetup.com/bostonrb/", target: "_blank") %>
         </div>
       </div>
     </div>

--- a/app/views/homes/_hero.html.erb
+++ b/app/views/homes/_hero.html.erb
@@ -1,7 +1,7 @@
 <main>
   <section class="hero">
     <h3 class="hero__tagline">
-      Hang out with Ruby enthusiasts
+      Connect with Ruby enthusiasts
     </h3>
     <%= link_to("Join our community!", "https://www.meetup.com/bostonrb/", target: "_blank", class: "hero__cta") %>
   </section>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,7 +22,7 @@
         </li>
 
         <li>
-          <%= link_to("Resources", "#") %>
+          <%= link_to("Slack", "http://slack.bostonrb.org/", target: "_blank") %>
         </li>
 
         <li>


### PR DESCRIPTION
Originally, we were to link the button in the About Us section to the
Slack signup, but this is a bit too tucked away. Instead, that button
will also link to the Meetup group and the Slack signup link will appear
in the header navigation.

In addition, I feel that "Connect with Ruby enthusiasts" feels more
encouraging of the kind of community we want to foster as opposed to
just "hanging out".

https://trello.com/c/XIyrYDro

Slack signup link in nav:
![boston ruby group 2018-03-09 12-52-08](https://user-images.githubusercontent.com/602470/37221662-b9810998-2398-11e8-9d00-b67635f39b31.jpg)


Button links to Meetup now:
![boston ruby group 2018-03-09 12-51-40](https://user-images.githubusercontent.com/602470/37221636-a6fe560e-2398-11e8-83bc-582caee1b499.jpg)
